### PR TITLE
feat: add support for redis 7.2 version

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -57,7 +57,7 @@ func TestRunRedisFSCloudExample(t *testing.T) {
 		*/
 		//ResourceGroup: resourceGroup,
 		TerraformVars: map[string]interface{}{
-			"redis_version":              "6.2", // Always lock this test into the latest supported Redis version
+			"redis_version":              "7.2", // Always lock this test into the latest supported Redis version
 			"existing_kms_instance_guid": permanentResources["hpcs_south"],
 			"kms_key_crn":                permanentResources["hpcs_south_root_key_crn"],
 		},

--- a/variables.tf
+++ b/variables.tf
@@ -14,9 +14,10 @@ variable "redis_version" {
   validation {
     condition = anytrue([
       var.redis_version == null,
-      var.redis_version == "6.2"
+      var.redis_version == "6.2",
+      var.redis_version == "7.2"
     ])
-    error_message = "Version must be 6.2. If no value passed, the current ICD preferred version is used."
+    error_message = "Version must be 6.2 or 7.2. If no value passed, the current ICD preferred version is used."
   }
 }
 


### PR DESCRIPTION
### Description

Icd service, used inside tests, return 7.2 redis version. We added support for it.

<img width="544" alt="image" src="https://github.com/terraform-ibm-modules/terraform-ibm-icd-redis/assets/106765658/d3bef073-1685-4d26-805e-c8ee20e7562a">


<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
