### PR TITLE
fix: mark `existing_kms_instance_crn` as required in the DA

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -330,6 +330,7 @@
             },
             {
               "key": "existing_kms_instance_crn"
+              "required": true
             },
             {
               "key": "existing_kms_key_crn"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -329,7 +329,7 @@
               "key": "ibmcloud_kms_api_key"
             },
             {
-              "key": "existing_kms_instance_crn"
+              "key": "existing_kms_instance_crn",
               "required": true
             },
             {

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -139,7 +139,7 @@ variable "ibmcloud_kms_api_key" {
 }
 
 variable "existing_kms_instance_crn" {
-  description = "The CRN of the KMS instance (Hyper Protect Crypto Services or Key Protect). Required only if `existing_kms_key_crn` is not specified. If the KMS instance is in different account you must also provide a value for `ibmcloud_kms_api_key`."
+  description = "The CRN of the KMS instance (Hyper Protect Crypto Services or Key Protect). Required to create a new root key if no value is passed with the `existing_kms_key_crn` input. Also required to create an authorization policy if `skip_iam_authorization_policy` is false. If the KMS instance is in different account you must also provide a value for `ibmcloud_kms_api_key`."
   type        = string
   default     = null
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -146,7 +146,7 @@ variable "existing_kms_instance_crn" {
 
 variable "existing_kms_key_crn" {
   type        = string
-  description = "The CRN of a Hyper Protect Crypto Services or Key Protect root key to use for disk encryption. If not specified, a new key ring and root key are created in the KMS instance."
+  description = "The CRN of a Hyper Protect Crypto Services or Key Protect root key to use for disk encryption. If not specified, a new key ring and root key are created in the KMS instance specified in the `existing_kms_instance_crn` input."
   default     = null
 }
 


### PR DESCRIPTION
### Description

- mark `existing_kms_instance_crn` as required in the DA to be consistent with other DAs. If user sets this value, then the DA will create the kms key and key ring, so this is a batter user experience. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
