### PR TITLE
fix: sync IBM catalog keys

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -255,6 +255,9 @@
               }
             },
             {
+              "key": "use_ibm_owned_encryption_key"
+            },
+            {
               "key": "ibmcloud_kms_api_key"
             },
             {
@@ -278,7 +281,7 @@
               ]
             },
             {
-              "key": "skip_iam_authorization_policy"
+              "key": "skip_redis_kms_auth_policy"
             },
             {
               "key": "key_ring_name"
@@ -313,6 +316,12 @@
             },
             {
               "key": "backup_crn"
+            },
+            {
+              "key": "existing_backup_kms_key_crn"
+            },
+            {
+              "key": "use_default_backup_encryption_key"
             }
           ]
         }


### PR DESCRIPTION
### Description

Re-fresh the IBM catalog JSON keys to match the DA.

No release is required, since the tile in the catalog was already fixed by the deployment pipeline.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
