### PR TITLE
Revert "fix: changed `users` input to `Multiline secure value`"

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -247,15 +247,7 @@
               "key": "skip_redis_kms_auth_policy"
             },
             {
-              "key": "users",
-              "custom_config": {
-                  "type": "multiline_secure_value",
-                  "grouping": "deployment",
-                  "original_grouping": "deployment",
-                  "config_constraints": {
-                      "type": "mixed"
-                  }
-              }
+              "key": "users"
             },
             {
               "key": "tags",


### PR DESCRIPTION
Reverts terraform-ibm-modules/terraform-ibm-icd-redis#549

see comment : https://github.ibm.com/GoldenEye/issues/issues/12988#issuecomment-107791159